### PR TITLE
Change Shape's focusPoint from a final field evaluated at an instance…

### DIFF
--- a/materialintro/src/main/java/com/codertainment/materialintro/shape/Shape.kt
+++ b/materialintro/src/main/java/com/codertainment/materialintro/shape/Shape.kt
@@ -9,12 +9,12 @@ import com.codertainment.materialintro.utils.Constants
 abstract class Shape @JvmOverloads constructor(
   protected var target: Target,
   protected var focus: Focus = Focus.MINIMUM,
-  focusGravity: FocusGravity = FocusGravity.CENTER,
+  private val focusGravity: FocusGravity = FocusGravity.CENTER,
   protected var padding: Int = Constants.DEFAULT_TARGET_PADDING
 ) {
 
   abstract fun draw(canvas: Canvas, eraser: Paint, padding: Int)
-  protected val focusPoint = when {
+  protected val focusPoint get() = when {
     focusGravity === FocusGravity.LEFT -> {
       val xLeft = target.rect.left + (target.point.x - target.rect.left) / 2
       Point(xLeft, target.point.y)


### PR DESCRIPTION
… creation to getter so that the focus point follows layout changes.

This change is to address an issue that the focus marker is drawn in the wrong position if the underlying layout changes between an intro view is created and shown.